### PR TITLE
Remove the discrete_ground_water.reading_qualifier column

### DIFF
--- a/liquibase/changeLogs/capture/tables/discreteGroundWater/changeLog.yml
+++ b/liquibase/changeLogs/capture/tables/discreteGroundWater/changeLog.yml
@@ -149,3 +149,19 @@ databaseChangeLog:
       changes:
         - sql: alter table ${AQTS_SCHEMA_NAME}.discrete_ground_water add column if not exists updated_at timestamptz not null default now();
         - rollback: alter table ${AQTS_SCHEMA_NAME}.discrete_ground_water drop column updated_at;
+
+  # After changes to use reading_qualifiers (plural) reading_qualifier is no longer needed
+  - changeSet:
+      author: eeverman
+      id: "alter.table.${AQTS_SCHEMA_NAME}.discrete_ground_water.drop.reading_qualifier"
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - columnExists:
+            schemaName: ${AQTS_SCHEMA_NAME}
+            tableName: discrete_ground_water
+            columnName: reading_qualifier
+      changes:
+        - sql: alter table ${AQTS_SCHEMA_NAME}.discrete_ground_water drop column if exists reading_qualifier;
+        - rollback: alter table ${AQTS_SCHEMA_NAME}.discrete_ground_water add column if not exists reading_qualifier text;
+


### PR DESCRIPTION
This columns is no longer used after switching to reading_qualifiers (plural)

Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
This is a bit of cleanup.  After completing this task:  https://internal.cida.usgs.gov/jira/browse/IOW-667
I realized that the existing column 'reading_qualifier' was not used through the entire stack.  And it shouldn't exist:  reading_qualifiers are multiple and are stored as a json array.
After completing two tasks that go top-to-bottom thru the stack, I'm confident this column isn't used and never should be.

Description
-----------
If no JIRA ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial